### PR TITLE
fix: put var in relevant loops

### DIFF
--- a/lib/mapboxgl-spiderifier.js
+++ b/lib/mapboxgl-spiderifier.js
@@ -157,11 +157,10 @@ function MapboxglSpiderfier(map, userOptions) {
 
   // Utility
   function eachFn(array, iterator) {
-    var i = 0;
     if (!array || !array.length) {
       return [];
     }
-    for (i = 0; i < array.length; i++) {
+    for (var i = 0; i < array.length; i++) {
       iterator(array[i], i)
     }
   }
@@ -170,7 +169,7 @@ function MapboxglSpiderfier(map, userOptions) {
     if (!count) {
       return [];
     }
-    for (i = 0; i < count; i++) {
+    for (var i = 0; i < count; i++) {
       iterator(i);
     }
   }


### PR DESCRIPTION
There is an error that is thrown within eachTimesFn if `var i` is not defined (especially if i export this as a common js module).